### PR TITLE
Add UI option to start filament numbering at 0

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1014,7 +1014,7 @@ static std::vector<std::string> s_Preset_printer_options {
     "nozzle_height", "master_extruder_id",
     "default_print_profile", "inherits",
     "silent_mode",
-    "scan_first_layer", "enable_power_loss_recovery", "wrapping_detection_layers", "wrapping_exclude_area", "machine_load_filament_time", "machine_unload_filament_time", "machine_tool_change_time", "time_cost", "machine_pause_gcode", "template_custom_gcode",
+    "scan_first_layer", "enable_power_loss_recovery", "wrapping_detection_layers", "wrapping_exclude_area", "machine_load_filament_time", "machine_unload_filament_time", "machine_tool_change_time", "start_filament_index_at_zero", "time_cost", "machine_pause_gcode", "template_custom_gcode",
     "nozzle_type", "nozzle_hrc","auxiliary_fan", "nozzle_volume","upward_compatible_machine", "z_hop_types", "travel_slope", "retract_lift_enforce","support_chamber_temp_control","support_air_filtration","printer_structure",
     "best_object_pos", "head_wrap_detect_zone",
     "host_type", "print_host", "printhost_apikey", "bbl_use_printhost",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2388,6 +2388,12 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat { 0. });
 
+    def = this->add("start_filament_index_at_zero", coBool);
+    def->label = L("Start filament index at 0");
+    def->tooltip = L("Display filament numbering starting from 0 in the UI. This does not affect generated G-code.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(false));
+
 
     def = this->add("support_object_skip_flush", coBool);
     def->set_default_value(new ConfigOptionBool(false));

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1364,6 +1364,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,               machine_load_filament_time))
     ((ConfigOptionFloat,               machine_tool_change_time))
     ((ConfigOptionFloat,               machine_unload_filament_time))
+    ((ConfigOptionBool,                start_filament_index_at_zero))
     ((ConfigOptionFloats,              filament_loading_speed))
     ((ConfigOptionFloats,              filament_loading_speed_start))
     ((ConfigOptionFloats,              filament_unloading_speed))

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -41,6 +41,21 @@ static int filaments_count()
     return wxGetApp().filaments_cnt();
 }
 
+static bool start_filament_index_at_zero()
+{
+    return wxGetApp().preset_bundle->printers.get_edited_preset().config.opt_bool("start_filament_index_at_zero");
+}
+
+static int filament_display_index_from_one_based(int index)
+{
+    return start_filament_index_at_zero() ? index - 1 : index;
+}
+
+static int filament_display_index_from_zero_based(int index)
+{
+    return start_filament_index_at_zero() ? index : index + 1;
+}
+
 static bool is_improper_category(const std::string& category, const int filaments_cnt, const bool is_object_settings = true)
 {
     return  category.empty() ||
@@ -925,7 +940,7 @@ void MenuFactory::append_menu_item_change_extruder(wxMenu* menu)
         if (i > 0) {
             auto preset = wxGetApp().preset_bundle->filaments.find_preset(wxGetApp().preset_bundle->filament_presets[i - 1]);
             if (preset == nullptr) {
-                item_name = wxString::Format(_L("Filament %d"), i);
+                item_name = wxString::Format(_L("Filament %d"), filament_display_index_from_one_based(i));
             } else {
                 item_name = from_u8(preset->label(false));
             }
@@ -1527,7 +1542,8 @@ void MenuFactory::create_filament_action_menu(bool init, int active_filament_men
             continue;
 
         auto preset = wxGetApp().preset_bundle->filaments.find_preset(wxGetApp().preset_bundle->filament_presets[i]);
-        wxString item_name = preset ? from_u8(preset->label(false)) : wxString::Format(_L("Filament %d"), i + 1);
+        wxString item_name = preset ? from_u8(preset->label(false))
+                                    : wxString::Format(_L("Filament %d"), filament_display_index_from_zero_based(i));
 
         append_menu_item(sub_menu, wxID_ANY, item_name, "",
             [i](wxCommandEvent&) { plater()->sidebar().change_filament(-2, i); }, *icons[i], menu,
@@ -2085,7 +2101,7 @@ void MenuFactory::append_menu_item_change_filament(wxMenu* menu)
         if (i > 0) {
             auto preset = wxGetApp().preset_bundle->filaments.find_preset(wxGetApp().preset_bundle->filament_presets[i - 1]);
             if (preset == nullptr) {
-                item_name = wxString::Format(_L("Filament %d"), i);
+                item_name = wxString::Format(_L("Filament %d"), filament_display_index_from_one_based(i));
             } else {
                 item_name = from_u8(preset->label(false));
             }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -882,6 +882,12 @@ static bool has_junction_deviation(const DynamicPrintConfig* printer_config)
 static DynamicFilamentList dynamic_filament_list;
 static DynamicFilamentList1Based dynamic_filament_list_1_based;
 
+static int filament_display_index_from_zero_based(int filament_idx)
+{
+    const bool start_zero = wxGetApp().preset_bundle->printers.get_edited_preset().config.opt_bool("start_filament_index_at_zero");
+    return filament_idx + (start_zero ? 0 : 1);
+}
+
 class AMSCountPopupWindow : public PopupWindow
 {
 public:
@@ -2277,7 +2283,7 @@ void Sidebar::init_filament_combo(PlaterPresetComboBox **combo, const int filame
     if ((filament_idx % 2) == 0) // Dont add right column item. this one create equal spacing on left, right & middle
         combo_and_btn_sizer->AddSpacer(FromDIP((filament_idx % 2) == 0 ? 12 : 3)); // Content Margin
 
-    (*combo)->clr_picker->SetLabel(wxString::Format("%d", filament_idx + 1));
+    (*combo)->clr_picker->SetLabel(wxString::Format("%d", filament_display_index_from_zero_based(filament_idx)));
     combo_and_btn_sizer->Add((*combo)->clr_picker, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(SidebarProps::ElementSpacing()) - FromDIP(2)); // ElementSpacing - 2 (from combo box))
     combo_and_btn_sizer->Add(*combo, 1, wxALL | wxEXPAND, FromDIP(2))->SetMinSize({-1, FromDIP(30)});
 
@@ -2456,9 +2462,21 @@ void Sidebar::update_all_preset_comboboxes()
         update_printer_thumbnail();
     }
 
+    update_filament_index_labels();
+
     // Orca:: show device tab based on vendor type
     p_mainframe->show_device(preset_bundle.use_bbl_device_tab());
     p_mainframe->m_tabpanel->SetSelection(p_mainframe->m_tabpanel->GetSelection());
+}
+
+void Sidebar::update_filament_index_labels()
+{
+    auto &combos_filament = p->combos_filament;
+    for (size_t index = 0; index < combos_filament.size(); ++index) {
+        combos_filament[index]->clr_picker->SetLabel(
+            wxString::Format("%d", filament_display_index_from_zero_based(static_cast<int>(index))));
+    }
+    Layout();
 }
 
 void Sidebar::update_presets(Preset::Type preset_type)

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -164,6 +164,7 @@ public:
     void update_all_preset_comboboxes();
     //void update_partplate(PartPlateList& list);
     void update_presets(Slic3r::Preset::Type preset_type);
+    void update_filament_index_labels();
     //BBS
     const std::vector<BedType>& get_cur_combox_bed_types() { return m_cur_combox_bed_types; }
     void update_presets_from_to(Slic3r::Preset::Type preset_type, std::string from, std::string to);

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1518,6 +1518,10 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
     if (opt_key == "single_extruder_multi_material" || opt_key == "extruders_count" )
         update_wiping_button_visibility();
 
+    if (opt_key == "start_filament_index_at_zero") {
+        wxGetApp().plater()->sidebar().update_filament_index_labels();
+    }
+
 
     if (opt_key == "pellet_flow_coefficient")
     {
@@ -4916,6 +4920,7 @@ if (is_marlin_flavor)
         optgroup->append_single_option_line("machine_load_filament_time", "printer_multimaterial_advanced#filament-load-time");
         optgroup->append_single_option_line("machine_unload_filament_time", "printer_multimaterial_advanced#filament-unload-time");
         optgroup->append_single_option_line("machine_tool_change_time", "printer_multimaterial_advanced#tool-change-time");
+        optgroup->append_single_option_line("start_filament_index_at_zero", "printer_multimaterial_advanced#filament-index-start");
         m_pages.insert(m_pages.end() - n_after_single_extruder_MM, page);
     }
 


### PR DESCRIPTION
### Motivation
- Provide an option in printer -> Multimaterial -> Advanced to let users choose zero-based filament numbering in the UI without changing G-code semantics.

### Description
- Add a new printer config option `start_filament_index_at_zero` in `PrintConfig` and include it in presets (`src/libslic3r/PrintConfig.hpp`, `src/libslic3r/PrintConfig.cpp`, `src/libslic3r/Preset.cpp`).
- Expose the option as a checkbox in the Multimaterial->Advanced options page (`src/slic3r/GUI/Tab.cpp`).
- Compute displayed filament labels using helper functions and use them where filament labels are created (sidebar combos and menus) by updating `GUI_Factories` and menu generation logic (`src/slic3r/GUI/GUI_Factories.cpp`).
- Update the sidebar code to produce the proper colour-picker labels and to refresh all filament index labels when the setting or presets change (`src/slic3r/GUI/Plater.cpp`, `src/slic3r/GUI/Plater.hpp`).
- Wire a refresh call so that changing `start_filament_index_at_zero` updates the UI immediately (`src/slic3r/GUI/Tab.cpp`).

### Testing
- No automated tests were executed for this change.
- The change compiles locally as part of the commit cycle (files staged and committed), but no `ctest` or CI results are included in this PR description.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696728d425408326b51ada4f63a9b26a)