### PR TITLE
Add 'Start filament index at 0' setting to Multimaterial → Advanced

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1014,7 +1014,7 @@ static std::vector<std::string> s_Preset_printer_options {
     "nozzle_height", "master_extruder_id",
     "default_print_profile", "inherits",
     "silent_mode",
-    "scan_first_layer", "enable_power_loss_recovery", "wrapping_detection_layers", "wrapping_exclude_area", "machine_load_filament_time", "machine_unload_filament_time", "machine_tool_change_time", "time_cost", "machine_pause_gcode", "template_custom_gcode",
+    "scan_first_layer", "enable_power_loss_recovery", "wrapping_detection_layers", "wrapping_exclude_area", "machine_load_filament_time", "machine_unload_filament_time", "machine_tool_change_time", "start_filament_index_at_zero", "time_cost", "machine_pause_gcode", "template_custom_gcode",
     "nozzle_type", "nozzle_hrc","auxiliary_fan", "nozzle_volume","upward_compatible_machine", "z_hop_types", "travel_slope", "retract_lift_enforce","support_chamber_temp_control","support_air_filtration","printer_structure",
     "best_object_pos", "head_wrap_detect_zone",
     "host_type", "print_host", "printhost_apikey", "bbl_use_printhost",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2388,6 +2388,12 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat { 0. });
 
+    def = this->add("start_filament_index_at_zero", coBool);
+    def->label = L("Start filament index at 0");
+    def->tooltip = L("Start filament/tool indexing from 0 instead of 1. Currently informational only.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(false));
+
 
     def = this->add("support_object_skip_flush", coBool);
     def->set_default_value(new ConfigOptionBool(false));

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1364,6 +1364,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,               machine_load_filament_time))
     ((ConfigOptionFloat,               machine_tool_change_time))
     ((ConfigOptionFloat,               machine_unload_filament_time))
+    ((ConfigOptionBool,                start_filament_index_at_zero))
     ((ConfigOptionFloats,              filament_loading_speed))
     ((ConfigOptionFloats,              filament_loading_speed_start))
     ((ConfigOptionFloats,              filament_unloading_speed))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -4916,6 +4916,7 @@ if (is_marlin_flavor)
         optgroup->append_single_option_line("machine_load_filament_time", "printer_multimaterial_advanced#filament-load-time");
         optgroup->append_single_option_line("machine_unload_filament_time", "printer_multimaterial_advanced#filament-unload-time");
         optgroup->append_single_option_line("machine_tool_change_time", "printer_multimaterial_advanced#tool-change-time");
+        optgroup->append_single_option_line("start_filament_index_at_zero", "printer_multimaterial_advanced#start-filament-index-at-zero");
         m_pages.insert(m_pages.end() - n_after_single_extruder_MM, page);
     }
 


### PR DESCRIPTION
### Motivation
- Add a toggle in the printer Multimaterial → Advanced UI to allow testing whether filament/tool indexing should start at 0 instead of 1; the flag is informational for now.

### Description
- Register a new boolean config `start_filament_index_at_zero` in `src/libslic3r/PrintConfig.hpp` and define it with label/tooltip/default in `src/libslic3r/PrintConfig.cpp`.
- Expose the new checkbox in the Multimaterial → Advanced optgroup via `src/slic3r/GUI/Tab.cpp` and add the key to `s_Preset_printer_options` in `src/libslic3r/Preset.cpp` so the setting is saved with printer presets.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967aaff620083269506b8b18c15345e)