### PR TITLE
Include start_filament_index_at_1 in printer preset options

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1024,7 +1024,8 @@ static std::vector<std::string> s_Preset_printer_options {
     "use_relative_e_distances", "extruder_type", "use_firmware_retraction", "printer_notes",
     "grab_length", "support_object_skip_flush", "physical_extruder_map",
     "cooling_tube_retraction",
-    "cooling_tube_length", "high_current_on_filament_swap", "parking_pos_retraction", "extra_loading_move", "purge_in_prime_tower", "enable_filament_ramming",
+    "cooling_tube_length", "high_current_on_filament_swap", "parking_pos_retraction", "extra_loading_move", "start_filament_index_at_1",
+    "purge_in_prime_tower", "enable_filament_ramming",
     "z_offset",
     "disable_m73", "preferred_orientation", "emit_machine_limits_to_gcode", "pellet_modded_printer", "support_multi_bed_types", "default_bed_type", "bed_mesh_min","bed_mesh_max","bed_mesh_probe_distance", "adaptive_bed_mesh_margin", "enable_long_retraction_when_cut","long_retractions_when_cut","retraction_distances_when_cut",
     "bed_temperature_formula", "nozzle_flush_dataset"


### PR DESCRIPTION
### Motivation
- The multimaterial UI and printer settings expect the new `start_filament_index_at_1` boolean option to be present in printer presets, and missing the key caused runtime errors and UI crashes when loading printer multimaterial pages.

### Description
- Add `start_filament_index_at_1` to the `s_Preset_printer_options` list in `src/libslic3r/Preset.cpp` so printer presets will include the new setting when applied or loaded.
- This is a single-line change to the preset option vector to ensure the multimaterial UI can query the key without triggering missing-config logic.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969da6526f08326965ae431c2d22573)