### PR TITLE
Handle missing bitmaps gracefully

### DIFF
--- a/src/slic3r/GUI/wxExtensions.cpp
+++ b/src/slic3r/GUI/wxExtensions.cpp
@@ -465,7 +465,7 @@ wxBitmap create_scaled_bitmap(  const std::string& bmp_name_in,
     if (bmp == nullptr) {
         // Neither SVG nor PNG has been found, raise error
         BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << "Could not load bitmap: " << bmp_name;
-        throw Slic3r::RuntimeError("Could not load bitmap: " + bmp_name);
+        return wxNullBitmap;
     }
 
     return *bmp;
@@ -485,7 +485,7 @@ wxBitmap create_scaled_bitmap2(const std::string& bmp_name_in, Slic3r::GUI::Bitm
     if (bmp == nullptr) {
         // No SVG found
         BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << "Could not load bitmap: " << bmp_name;
-        throw Slic3r::RuntimeError("Could not load bitmap: " + bmp_name);
+        return wxNullBitmap;
     }
     return *bmp;
 }
@@ -1360,7 +1360,6 @@ void ImageTransientPopup::OnMouse(wxMouseEvent &event)
 {
     event.Skip();
 }
-
 
 
 


### PR DESCRIPTION
### Motivation
- Prevent the UI from throwing a `Slic3r::RuntimeError` and freezing/crashing when expected SVG/PNG bitmap assets are missing (observed during debug launch and when opening multimaterial printer settings). 

### Description
- Replace thrown runtime errors in `create_scaled_bitmap` and `create_scaled_bitmap2` with returning `wxNullBitmap` so missing bitmaps are handled gracefully (file: `src/slic3r/GUI/wxExtensions.cpp`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969ec791a348326888351bf7eed7b1e)