### PR TITLE
Store filament index setting in printer presets

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1024,7 +1024,8 @@ static std::vector<std::string> s_Preset_printer_options {
     "use_relative_e_distances", "extruder_type", "use_firmware_retraction", "printer_notes",
     "grab_length", "support_object_skip_flush", "physical_extruder_map",
     "cooling_tube_retraction",
-    "cooling_tube_length", "high_current_on_filament_swap", "parking_pos_retraction", "extra_loading_move", "purge_in_prime_tower", "enable_filament_ramming",
+    "cooling_tube_length", "high_current_on_filament_swap", "parking_pos_retraction", "extra_loading_move", "start_filament_index_at_1",
+    "purge_in_prime_tower", "enable_filament_ramming",
     "z_offset",
     "disable_m73", "preferred_orientation", "emit_machine_limits_to_gcode", "pellet_modded_printer", "support_multi_bed_types", "default_bed_type", "bed_mesh_min","bed_mesh_max","bed_mesh_probe_distance", "adaptive_bed_mesh_margin", "enable_long_retraction_when_cut","long_retractions_when_cut","retraction_distances_when_cut",
     "bed_temperature_formula", "nozzle_flush_dataset"


### PR DESCRIPTION
### Motivation

- Persist the `start_filament_index_at_1` option with printer presets so the filament index base choice is saved and restored like other printer settings.

### Description

- Added `start_filament_index_at_1` to the printer options list in `src/libslic3r/Preset.cpp` so it will be exported/loaded with printer presets.

### Testing

- No automated tests were run for this small change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a661d92b08326a5842258c690586a)