### PR TITLE
Refresh tool numbering after filament index toggle

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1537,6 +1537,12 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
         wxGetApp().get_tab(Preset::TYPE_PRINT)->update();
     }
 
+    if (opt_key == "start_filament_index_at_1") {
+        wxGetApp().sidebar().update_dynamic_filament_list();
+        wxGetApp().sidebar().update_all_preset_comboboxes();
+        wxGetApp().plater()->update();
+    }
+
     if(opt_key == "purge_in_prime_tower")
         wxGetApp().get_tab(Preset::TYPE_PRINT)->update();
 


### PR DESCRIPTION
### Motivation
- Ensure the UI immediately reflects the change when `start_filament_index_at_1` is toggled so filament/tool numbering switches between 0-based and 1-based without requiring a restart or manual refresh.

### Description
- When `start_filament_index_at_1` changes in `Tab::on_value_change`, call `wxGetApp().sidebar().update_dynamic_filament_list()`, `wxGetApp().sidebar().update_all_preset_comboboxes()` and `wxGetApp().plater()->update()` to refresh filament lists, preset comboboxes and plater UI.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a69afb490832694f6ae427e479264)