### PR TITLE
Rename filament index setting to start_filament_index_at_0 and move to Advanced

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1024,7 +1024,7 @@ static std::vector<std::string> s_Preset_printer_options {
     "use_relative_e_distances", "extruder_type", "use_firmware_retraction", "printer_notes",
     "grab_length", "support_object_skip_flush", "physical_extruder_map",
     "cooling_tube_retraction",
-    "cooling_tube_length", "high_current_on_filament_swap", "parking_pos_retraction", "extra_loading_move", "start_filament_index_at_1",
+    "cooling_tube_length", "high_current_on_filament_swap", "parking_pos_retraction", "extra_loading_move", "start_filament_index_at_0",
     "purge_in_prime_tower", "enable_filament_ramming",
     "z_offset",
     "disable_m73", "preferred_orientation", "emit_machine_limits_to_gcode", "pellet_modded_printer", "support_multi_bed_types", "default_bed_type", "bed_mesh_min","bed_mesh_max","bed_mesh_probe_distance", "adaptive_bed_mesh_margin", "enable_long_retraction_when_cut","long_retractions_when_cut","retraction_distances_when_cut",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4428,12 +4428,12 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(-2.));
 
-    def          = this->add("start_filament_index_at_1", coBool);
-    def->label   = L("Start filament index at 1");
-    def->tooltip = L("When enabled, filament/extruder indices are treated as 1-based (1..N) instead of 0-based (0..N-1). "
-                     "Enable this if your firmware / macros expect filament indices starting at 1.");
+    def          = this->add("start_filament_index_at_0", coBool);
+    def->label   = L("Start filament index at 0");
+    def->tooltip = L("When enabled, filament/extruder indices are treated as 0-based (0..N-1) instead of 1-based (1..N). "
+                     "Disable this if your firmware / macros expect filament indices starting at 1.");
     def->mode    = comAdvanced;
-    def->set_default_value(new ConfigOptionBool(false));
+    def->set_default_value(new ConfigOptionBool(true));
 
     def = this->add("start_end_points", coPoints);
     def->label = L("Start end points");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1385,7 +1385,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionBool,                purge_in_prime_tower))
     ((ConfigOptionBool,                enable_filament_ramming))
     ((ConfigOptionBool,                support_multi_bed_types))
-    ((ConfigOptionBool,                start_filament_index_at_1))
+    ((ConfigOptionBool,                start_filament_index_at_0))
 
 
     // Small Area Infill Flow Compensation

--- a/src/slic3r/GUI/GUI.cpp
+++ b/src/slic3r/GUI/GUI.cpp
@@ -102,25 +102,25 @@ const std::string& shortkey_alt_prefix()
 	return str;
 }
 
-bool start_filament_index_at_1()
+bool start_filament_index_at_0()
 {
     const auto* preset_bundle = wxGetApp().preset_bundle;
     if (!preset_bundle)
         return false;
 
     const auto& config = preset_bundle->printers.get_edited_preset().config;
-    const auto* opt = config.option<ConfigOptionBool>("start_filament_index_at_1");
+    const auto* opt = config.option<ConfigOptionBool>("start_filament_index_at_0");
     return opt != nullptr && opt->value;
 }
 
 int filament_index_from_zero_based(int index)
 {
-    return index + (start_filament_index_at_1() ? 1 : 0);
+    return index + (start_filament_index_at_0() ? 0 : 1);
 }
 
 int filament_index_from_one_based(int index)
 {
-    return start_filament_index_at_1() ? index : index - 1;
+    return start_filament_index_at_0() ? index - 1 : index;
 }
 
 // opt_index = 0, by the reason of zero-index in ConfigOptionVector by default (in case only one element)

--- a/src/slic3r/GUI/GUI.hpp
+++ b/src/slic3r/GUI/GUI.hpp
@@ -32,7 +32,7 @@ void break_to_debugger();
 extern const std::string& shortkey_ctrl_prefix();
 extern const std::string& shortkey_alt_prefix();
 
-bool start_filament_index_at_1();
+bool start_filament_index_at_0();
 int filament_index_from_zero_based(int index);
 int filament_index_from_one_based(int index);
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1537,7 +1537,7 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
         wxGetApp().get_tab(Preset::TYPE_PRINT)->update();
     }
 
-    if (opt_key == "start_filament_index_at_1") {
+    if (opt_key == "start_filament_index_at_0") {
         wxGetApp().sidebar().update_dynamic_filament_list();
         wxGetApp().sidebar().update_all_preset_comboboxes();
         wxGetApp().plater()->update();
@@ -4917,12 +4917,11 @@ if (is_marlin_flavor)
         optgroup->append_single_option_line("parking_pos_retraction", "printer_multimaterial_semm_parameters#filament-parking-position");
         optgroup->append_single_option_line("extra_loading_move", "printer_multimaterial_semm_parameters#extra-loading-distance");
         optgroup->append_single_option_line("high_current_on_filament_swap", "printer_multimaterial_semm_parameters#high-extruder-current-on-filament-swap");
-        optgroup->append_single_option_line("start_filament_index_at_1", "printer_multimaterial_semm_parameters#start_filament_index_at_1");
-
         optgroup = page->new_optgroup(L("Advanced"), L"param_advanced");
         optgroup->append_single_option_line("machine_load_filament_time", "printer_multimaterial_advanced#filament-load-time");
         optgroup->append_single_option_line("machine_unload_filament_time", "printer_multimaterial_advanced#filament-unload-time");
         optgroup->append_single_option_line("machine_tool_change_time", "printer_multimaterial_advanced#tool-change-time");
+        optgroup->append_single_option_line("start_filament_index_at_0", "printer_multimaterial_advanced#start-filament-index-at-0");
         m_pages.insert(m_pages.end() - n_after_single_extruder_MM, page);
     }
 


### PR DESCRIPTION
### Motivation

- Make the filament/extruder index option clarifyingly 0-based by default and relocate it to the Advanced group for multi-material printer settings.
- Ensure UI and internal index-conversion logic reflect the new option name and semantics.

### Description

- Renamed the config option `start_filament_index_at_1` to `start_filament_index_at_0` and updated the label and tooltip to reflect 0-based indexing semantics in `src/libslic3r/PrintConfig.cpp` and `src/libslic3r/PrintConfig.hpp`.
- Changed the default so the option is enabled by default (`new ConfigOptionBool(true)`), meaning 0-based indices are used unless disabled.
- Updated preset mapping to include `start_filament_index_at_0` in `s_Preset_printer_options` in `src/libslic3r/Preset.cpp`.
- Updated GUI API and logic: renamed the helper to `start_filament_index_at_0()` and adjusted `filament_index_from_zero_based` / `filament_index_from_one_based` behavior in `src/slic3r/GUI/GUI.cpp` and declaration in `src/slic3r/GUI/GUI.hpp`.
- Moved the UI option from the "Single extruder multi-material parameters" group into the "Advanced" group in the printer tab and updated the change handler to check `opt_key == "start_filament_index_at_0"` in `src/slic3r/GUI/Tab.cpp`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a6fd3be2083269276c71b9a65fc50)