### PR TITLE
Honor start_filament_index_at_0 when displaying and parsing filament/extruder indices

### DIFF
--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -4,6 +4,7 @@
 #include "GUI_Factories.hpp"
 //#include "GUI_ObjectLayers.hpp"
 #include "GUI_App.hpp"
+#include "GUI.hpp"
 #include "I18N.hpp"
 #include "Plater.hpp"
 #include "BitmapComboBox.hpp"
@@ -75,6 +76,14 @@ static DynamicPrintConfig& printer_config()
 static int filaments_count()
 {
     return wxGetApp().filaments_cnt();
+}
+
+static wxString format_filament_index_for_display(int extruder_id)
+{
+    if (extruder_id <= 0)
+        return wxString::Format("%d", extruder_id);
+
+    return wxString::Format("%d", filament_index_from_one_based(extruder_id));
 }
 
 static void take_snapshot(const std::string& snapshot_name)
@@ -688,11 +697,11 @@ void ObjectList::update_filament_values_for_items(const size_t filaments_count)
         auto object = (*m_objects)[i];
         wxString extruder;
         if (!object->config.has("extruder") || size_t(object->config.extruder()) > filaments_count) {
-            extruder = "1";
+            extruder = format_filament_index_for_display(1);
             object->config.set_key_value("extruder", new ConfigOptionInt(1));
         }
         else {
-            extruder = wxString::Format("%d", object->config.extruder());
+            extruder = format_filament_index_for_display(object->config.extruder());
         }
         m_objects_model->SetExtruder(extruder, item);
 
@@ -707,10 +716,10 @@ void ObjectList::update_filament_values_for_items(const size_t filaments_count)
                 if (!item) continue;
                 if (!object->volumes[id]->config.has("extruder") ||
                     size_t(object->volumes[id]->config.extruder()) > filaments_count) {
-                    extruder = wxString::Format("%d", object->config.extruder());
+                    extruder = format_filament_index_for_display(object->config.extruder());
                 }
                 else {
-                    extruder = wxString::Format("%d", object->volumes[id]->config.extruder());
+                    extruder = format_filament_index_for_display(object->volumes[id]->config.extruder());
                 }
 
                 m_objects_model->SetExtruder(extruder, item);
@@ -737,15 +746,15 @@ void ObjectList::update_filament_values_for_items_when_delete_filament(const siz
         auto     object = (*m_objects)[i];
         wxString extruder;
         if (!object->config.has("extruder")) {
-            extruder = std::to_string(1);
+            extruder = format_filament_index_for_display(1);
             object->config.set_key_value("extruder", new ConfigOptionInt(1));
         }
         else if (size_t(object->config.extruder()) == filament_id + 1) {
-            extruder = std::to_string(replace_filament_id);
+            extruder = format_filament_index_for_display(replace_filament_id);
             object->config.set_key_value("extruder", new ConfigOptionInt(replace_filament_id));
         } else {
             int new_extruder = object->config.extruder() > filament_id ? object->config.extruder() - 1 : object->config.extruder();
-            extruder = wxString::Format("%d", new_extruder);
+            extruder = format_filament_index_for_display(new_extruder);
             object->config.set_key_value("extruder", new ConfigOptionInt(new_extruder));
         }
         m_objects_model->SetExtruder(extruder, item);
@@ -787,7 +796,7 @@ void ObjectList::update_filament_values_for_items_when_delete_filament(const siz
                     object->volumes[id]->config.set_key_value("extruder", new ConfigOptionInt(replace_filament_id));
                 } else {
                     int new_extruder = object->volumes[id]->config.extruder() > filament_id ? object->volumes[id]->config.extruder() - 1 : object->volumes[id]->config.extruder();
-                    extruder = wxString::Format("%d", new_extruder);
+                    extruder = format_filament_index_for_display(new_extruder);
                     object->volumes[id]->config.set_key_value("extruder", new ConfigOptionInt(new_extruder));
                 }
 
@@ -815,12 +824,12 @@ void ObjectList::update_filament_values_for_items_when_delete_filament(const siz
                     auto& layer_range_item = *(l_iter);
                     if (layer_range_item.second.has("extruder") && layer_range_item.second.option("extruder")->getInt() == filament_id + 1) {
                         int new_extruder = replace_id == -1 ? 0 : (replace_id + 1);
-                        extruder         = wxString::Format("%d", new_extruder);
+                        extruder         = format_filament_index_for_display(new_extruder);
                         layer_range_item.second.set("extruder", new_extruder);
                     } else {
                         int layer_filament_id = layer_range_item.second.option("extruder")->getInt();
                         int new_extruder      = layer_filament_id > filament_id ? layer_filament_id - 1 : layer_filament_id;
-                        extruder              = wxString::Format("%d", new_extruder);
+                        extruder              = format_filament_index_for_display(new_extruder);
                         layer_range_item.second.set("extruder", new_extruder);
                     }
                     m_objects_model->SetExtruder(extruder, layer_item);
@@ -1608,7 +1617,7 @@ void ObjectList::extruder_editing()
     pos.x = GetColumn(colName)->GetWidth() + GetColumn(colPrint)->GetWidth() + GetColumn(colHeight)->GetWidth() + 5;
     pos.y -= GetTextExtent("m").y;
 
-    apply_extruder_selector(&m_extruder_editor, this, "1", pos, size);
+    apply_extruder_selector(&m_extruder_editor, this, format_filament_index_for_display(1).ToStdString(), pos, size);
 
     m_extruder_editor->SetSelection(m_objects_model->GetExtruderNumber(item));
     m_extruder_editor->Show();
@@ -2772,7 +2781,7 @@ bool ObjectList::del_subobject_from_object(const int obj_idx, const int idx, con
                         int extruder_id = last_volume->config.opt_int("extruder");
                         object->config.set("extruder", extruder_id);
                     }
-                    wxString extruder = object->config.has("extruder") ? wxString::Format("%d", object->config.extruder()) : _devL("1");
+                    wxString extruder = object->config.has("extruder") ? format_filament_index_for_display(object->config.extruder()) : format_filament_index_for_display(1);
                     m_objects_model->SetExtruder(extruder, obj_item);
                 }
                 // add settings to the object, if it has them
@@ -4168,7 +4177,7 @@ void ObjectList::delete_from_model_and_list(const std::vector<ItemForDelete>& it
                 if (obj->volumes.size() == 1) {
                     wxDataViewItem parent = m_objects_model->GetItemById(item->obj_idx);
                     if (obj->config.has("extruder")) {
-                        const wxString extruder = wxString::Format("%d", obj->config.extruder());
+                        const wxString extruder = format_filament_index_for_display(obj->config.extruder());
                         m_objects_model->SetExtruder(extruder, parent);
                     }
                     // If last volume item with warning was deleted, unmark object item
@@ -6183,7 +6192,7 @@ void ObjectList::set_extruder_for_selected_items(const int extruder)
             }
         }
 
-        const wxString extruder_str = wxString::Format("%d", new_extruder);
+        const wxString extruder_str = format_filament_index_for_display(new_extruder);
         m_objects_model->SetExtruder(extruder_str, item);
     }
 

--- a/src/slic3r/GUI/ObjectDataViewModel.cpp
+++ b/src/slic3r/GUI/ObjectDataViewModel.cpp
@@ -10,6 +10,7 @@
 
 #include "libslic3r/Model.hpp"
 
+#include <cstdlib>
 #include <wx/bmpcbox.h>
 #include <wx/dc.h>
 
@@ -43,6 +44,14 @@ static constexpr char LayerIcon[]       = "height_range_layer";
 static constexpr char WarningIcon[]     = "obj_warning";
 static constexpr char WarningManifoldIcon[] = "obj_warning";
 static constexpr char LockIcon[]            = "cut_";
+
+static wxString format_filament_index_for_display(int extruder_id)
+{
+    if (extruder_id <= 0)
+        return wxString::Format("%d", extruder_id);
+
+    return wxString::Format("%d", filament_index_from_one_based(extruder_id));
+}
 
 ObjectDataViewModelNode::ObjectDataViewModelNode(PartPlate* part_plate, wxString name) :
     m_parent(nullptr),
@@ -611,7 +620,7 @@ wxDataViewItem ObjectDataViewModel::AddObject(ModelObject *model_object, std::st
 
     // create object node
     //const wxString extruder_str = extruder == 0 ? _(L("default")) : wxString::Format("%d", extruder);
-    const wxString extruder_str = wxString::Format("%d", extruder);
+    const wxString extruder_str = format_filament_index_for_display(extruder);
     auto obj_node = new ObjectDataViewModelNode(name, extruder_str, plate_idx, model_object);
     // Add warning icon if detected auto-repaire
     UpdateBitmapForNode(obj_node, warning_bitmap, has_lock);
@@ -678,7 +687,7 @@ wxDataViewItem ObjectDataViewModel::AddVolumeChild( const wxDataViewItem &parent
             extruder_str = root->m_extruder;
     }
     else {
-        extruder_str = wxString::Format("%d", extruder);
+        extruder_str = format_filament_index_for_display(extruder);
     }
 
     const auto node = new ObjectDataViewModelNode(root, name, volume_type, is_text_volume, is_svg_volume, extruder_str, root->m_volumes_cnt);
@@ -905,7 +914,7 @@ wxDataViewItem ObjectDataViewModel::AddLayersChild(const wxDataViewItem &parent_
     if (!parent_node) return wxDataViewItem(0);
 
     // BBS
-    wxString extruder_str = extruder == 0 ? _(L("default")) : wxString::Format("%d", extruder);
+    wxString extruder_str = extruder == 0 ? _(L("default")) : format_filament_index_for_display(extruder);
 
     // get LayerRoot node
     ObjectDataViewModelNode *layer_root_node;
@@ -1748,7 +1757,16 @@ int ObjectDataViewModel::GetExtruderNumber(const wxDataViewItem& item) const
 	if (!node)      // happens if item.IsOk()==false
 		return 0;
 
-	return atoi(node->m_extruder.c_str());
+    const std::string extruder = node->m_extruder.ToStdString();
+    char* end                  = nullptr;
+    const long value           = std::strtol(extruder.c_str(), &end, 10);
+    if (end == extruder.c_str() || *end != '\0')
+        return 0;
+
+    if (start_filament_index_at_0())
+        return static_cast<int>(value) + 1;
+
+    return static_cast<int>(value);
 }
 
 wxString ObjectDataViewModel::GetColumnType(unsigned int col) const
@@ -2494,5 +2512,3 @@ void ObjectDataViewModel::UpdateCutObjectIcon(const wxDataViewItem &item, bool h
 
 } // namespace GUI
 } // namespace Slic3r
-
-

--- a/src/slic3r/GUI/wxExtensions.cpp
+++ b/src/slic3r/GUI/wxExtensions.cpp
@@ -790,9 +790,10 @@ void apply_extruder_selector(Slic3r::GUI::BitmapComboBox** ctrl,
             ++i;
         }
 
+        const int display_index = filament_index_from_one_based(i);
         (*ctrl)->Append(use_full_item_name
-                        ? Slic3r::GUI::from_u8((boost::format("%1% %2%") % str % i).str())
-                        : wxString::Format("%d", i), *bmp);
+                        ? Slic3r::GUI::from_u8((boost::format("%1% %2%") % str % display_index).str())
+                        : wxString::Format("%d", display_index), *bmp);
         ++i;
     }
     (*ctrl)->SetSelection(0);
@@ -1360,7 +1361,6 @@ void ImageTransientPopup::OnMouse(wxMouseEvent &event)
 {
     event.Skip();
 }
-
 
 
 


### PR DESCRIPTION
### Motivation
- `start_filament_index_at_0` is documented to make filament/extruder indices in the UI 0-based, but the object list and extruder selector were still showing/parsing indices as if they were always 1-based, causing mismatch between UI labels and internal values.

### Description
- Added `format_filament_index_for_display` and applied it across `src/slic3r/GUI/GUI_ObjectList.cpp` and `src/slic3r/GUI/ObjectDataViewModel.cpp` so UI labels show the correct index according to `start_filament_index_at_0`.
- Updated the extruder selector in `src/slic3r/GUI/wxExtensions.cpp` to display filament names using the display index instead of the raw internal index.
- Made `ObjectDataViewModel::GetExtruderNumber` robust by parsing the displayed extruder string with `std::strtol` and converting it back to the internal index when `start_filament_index_at_0()` is enabled.
- Small include and plumbing changes to ensure conversions compile (`#include <cstdlib>`) and to swap existing `wxString::Format`/`std::to_string` usages for the new display helper in multiple places that set or update extruder labels.

### Testing
- No automated tests were executed in this change; no `ctest` or CI runs were performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a88c304008326a178d60f83a59ab5)