### PR TITLE
Respect start_filament_index_at_0 in UI labels, shortcuts and overlays

### DIFF
--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -345,11 +345,11 @@ void GCodeViewer::SequentialView::Marker::render_position_window(const libvgcode
                 break;
             }
             case libvgcode::EViewType::Tool: {
-                sprintf(buf, "%s %s%d", buf, _u8L("Tool: ").c_str(), vertex.extruder_id + 1);
+                sprintf(buf, "%s %s%d", buf, _u8L("Tool: ").c_str(), filament_index_from_zero_based(static_cast<int>(vertex.extruder_id)));
                 break;
             }
             case libvgcode::EViewType::ColorPrint: {
-                sprintf(buf, "%s %s%d", buf, _u8L("Color: ").c_str(), vertex.color_id + 1);
+                sprintf(buf, "%s %s%d", buf, _u8L("Color: ").c_str(), filament_index_from_zero_based(static_cast<int>(vertex.color_id)));
                 break;
             }
             case libvgcode::EViewType::ActualVolumetricFlowRate: {
@@ -2480,7 +2480,7 @@ void GCodeViewer::render_all_plates_stats(const std::vector<const GCodeProcessor
         for (auto it = model_volume_of_extruders_all_plates.begin(); it != model_volume_of_extruders_all_plates.end(); it++) {
             if (i < model_used_filaments_m_all_plates.size() && i < model_used_filaments_g_all_plates.size()) {
                 std::vector<std::pair<std::string, float>> columns_offsets;
-                columns_offsets.push_back({ std::to_string(it->first + 1), offsets[_u8L("Filament")]});
+                columns_offsets.push_back({ std::to_string(filament_index_from_zero_based(static_cast<int>(it->first))), offsets[_u8L("Filament")]});
 
                 char buf[64];
                 double unit_conver = imperial_units ? GizmoObjectManipulation::oz_to_g : 1.0;
@@ -3562,7 +3562,7 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
         const std::vector<uint8_t>& used_extruders_ids = m_viewer.get_used_extruders_ids();
         for (uint8_t extruder_id : used_extruders_ids) {
             ::sprintf(buf, imperial_units ? "%.2f in    %.2f g" : "%.2f m    %.2f g", model_used_filaments_m[i], model_used_filaments_g[i]);
-            append_item(EItemType::Rect, libvgcode::convert(m_viewer.get_tool_colors()[extruder_id]), { { _u8L("Extruder") + " " + std::to_string(extruder_id + 1), offsets[0]}, {buf, offsets[1]} });
+            append_item(EItemType::Rect, libvgcode::convert(m_viewer.get_tool_colors()[extruder_id]), { { _u8L("Extruder") + " " + std::to_string(filament_index_from_zero_based(extruder_id)), offsets[0]}, {buf, offsets[1]} });
             // append_item(EItemType::Rect, libvgcode::convert(m_viewer.get_tool_colors()[extruder_id]), _u8L("Extruder") + " " + std::to_string(extruder_id + 1),
             // true, "", 0.0f, 0.0f, offsets, used_filaments_m[extruder_id], used_filaments_g[extruder_id]);
             i++;
@@ -3614,7 +3614,7 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
         for (auto extruder_idx : used_extruders_ids) {
             if (i < model_used_filaments_m.size() && i < model_used_filaments_g.size()) {
                 std::vector<std::pair<std::string, float>> columns_offsets;
-                columns_offsets.push_back({ std::to_string(extruder_idx + 1), color_print_offsets[_u8L("Filament")]});
+                columns_offsets.push_back({ std::to_string(filament_index_from_zero_based(extruder_idx)), color_print_offsets[_u8L("Filament")]});
 
                 char buf[64];
                 float column_sum_m = 0.0f;
@@ -3990,7 +3990,7 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
                 ret = std::max(ret, ImGui::CalcTextSize((_u8L("Print settings") + std::string(":")).c_str()).x);
             if (!m_settings_ids.filament.empty()) {
                 for (unsigned char i : m_viewer.get_used_extruders_ids()) {
-                    ret = std::max(ret, ImGui::CalcTextSize((_u8L("Filament") + " " + std::to_string(i + 1) + ":").c_str()).x);
+                    ret = std::max(ret, ImGui::CalcTextSize((_u8L("Filament") + " " + std::to_string(filament_index_from_zero_based(static_cast<int>(i))) + ":").c_str()).x);
                 }
             }
             if (ret > 0.0f)
@@ -4017,7 +4017,7 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
             for (unsigned char i : m_viewer.get_used_extruders_ids()) {
                 if (i < static_cast<unsigned char>(m_settings_ids.filament.size()) && !m_settings_ids.filament[i].empty()) {
                     std::string txt = _u8L("Filament");
-                    txt += (m_viewer.get_used_extruders_count() == 1) ? ":" : " " + std::to_string(i + 1);
+                    txt += (m_viewer.get_used_extruders_count() == 1) ? ":" : " " + std::to_string(filament_index_from_zero_based(static_cast<int>(i)));
                     imgui.text(txt);
                     ImGui::SameLine(offset);
                     imgui.text(m_settings_ids.filament[i]);
@@ -4266,4 +4266,3 @@ void GCodeViewer::render_slider(int canvas_width, int canvas_height) {
 
 } // namespace GUI
 } // namespace Slic3r
-

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -9492,14 +9492,15 @@ void GLCanvas3D::_set_warning_notification(EWarning warning, bool state)
             if (error_iter != m_gcode_viewer.m_gcode_check_result.print_area_error_infos.begin()) {
                 text += "\n";
             }
-            int extruder_id = error_iter->first + 1; // change extruder id to 1 based
+            const int extruder_index = error_iter->first;
+            const int extruder_id = filament_index_from_zero_based(extruder_index);
             std::string filaments;
             std::vector<int> slice_error_object_idxs;
             for (size_t i = 0; i < error_iter->second.size(); ++i) {
                 if (i > 0) {
                     filaments += ", ";
                 }
-                int filament_id = error_iter->second[i].first + 1; // change filament id to 1 based
+                const int filament_id = filament_index_from_zero_based(error_iter->second[i].first);
                 int object_label_id = error_iter->second[i].second;
 
                 filaments += std::to_string(filament_id);
@@ -9522,7 +9523,7 @@ void GLCanvas3D::_set_warning_notification(EWarning warning, bool state)
                     }
                 }
             }
-            std::string extruder_name = extruder_name_list[extruder_id-1];
+            std::string extruder_name = extruder_name_list[extruder_index];
             if (error_iter->second.size() == 1) {
                 text += (boost::format(_u8L("Filament %s is placed in the %s, but the generated G-code path exceeds the printable range of the %s.")) %filaments %extruder_name %extruder_name).str();
             }
@@ -9538,11 +9539,12 @@ void GLCanvas3D::_set_warning_notification(EWarning warning, bool state)
             if (error_iter != m_gcode_viewer.m_gcode_check_result.print_height_error_infos.begin()) {
                 text += "\n";
             }
-            int              extruder_id = error_iter->first + 1; // change extruder id to 1 based
+            const int        extruder_index = error_iter->first;
+            const int        extruder_id = filament_index_from_zero_based(extruder_index);
             std::set<int>    filament_ids;
             std::vector<int> slice_error_object_idxs;
             for (size_t i = 0; i < error_iter->second.size(); ++i) {
-                int filament_id     = error_iter->second[i].first + 1; // change filament id to 1 based
+                int filament_id     = filament_index_from_zero_based(error_iter->second[i].first);
                 int object_label_id = error_iter->second[i].second;
                 filament_ids.insert(filament_id);
                 for (int object_idx = 0; object_idx < (int) m_model->objects.size(); ++object_idx) {
@@ -9575,7 +9577,7 @@ void GLCanvas3D::_set_warning_notification(EWarning warning, bool state)
                     }
                 }
             }
-            std::string extruder_name = extruder_name_list[extruder_id-1];
+            std::string extruder_name = extruder_name_list[extruder_index];
             if (error_iter->second.size() == 1) {
                 text += (boost::format(_u8L("Filament %s is placed in the %s, but the generated G-code path exceeds the printable height of the %s.")) % filaments % extruder_name % extruder_name).str();
             } else {
@@ -9604,7 +9606,7 @@ void GLCanvas3D::_set_warning_notification(EWarning warning, bool state)
         const std::vector<int> &conflict_filament = m_gcode_viewer.filament_printable_reuslt.conflict_filament;
         auto                    iter              = conflict_filament.begin();
         for (int filament : conflict_filament) {
-            warning += std::to_string(filament + 1);
+            warning += std::to_string(filament_index_from_zero_based(filament));
             warning += " ";
         }
         text  = (boost::format(_u8L("filaments %s cannot be printed directly on the surface of this plate.")) % warning).str();

--- a/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
@@ -192,7 +192,7 @@ void GLGizmoMmuSegmentation::data_changed(bool is_serializing)
 // BBS
 bool GLGizmoMmuSegmentation::on_number_key_down(int number)
 {
-    int extruder_idx = number - 1;
+    int extruder_idx = start_filament_index_at_0() ? number : number - 1;
     if (extruder_idx < m_extruders_colors.size() && extruder_idx >= 0)
         m_selected_extruder_idx = extruder_idx;
 
@@ -403,7 +403,7 @@ void GLGizmoMmuSegmentation::on_render_input_window(float x, float y, float bott
         const ColorRGBA &extruder_color = m_extruders_colors[extruder_idx];
         ImVec4           color_vec      = ImGuiWrapper::to_ImVec4(extruder_color);
         std::string color_label = std::string("##extruder color ") + std::to_string(extruder_idx);
-        std::string item_text = std::to_string(extruder_idx + 1);
+        std::string item_text = std::to_string(filament_index_from_zero_based(extruder_idx));
         const ImVec2 label_size = ImGui::CalcTextSize(item_text.c_str(), NULL, true);
 
         const ImVec2 button_size(max_label_size.x + m_imgui->scaled(0.5f),0.f);
@@ -435,7 +435,8 @@ void GLGizmoMmuSegmentation::on_render_input_window(float x, float y, float bott
         color_button_high = ImGui::GetCursorPos().y - color_button - 2.0;
         if (color_picked) { m_selected_extruder_idx = extruder_idx; }
 
-        if (extruder_idx < 16 && ImGui::IsItemHovered()) m_imgui->tooltip(_L("Shortcut Key ") + std::to_string(extruder_idx + 1), max_tooltip_width);
+        if (extruder_idx < 16 && ImGui::IsItemHovered())
+            m_imgui->tooltip(_L("Shortcut Key ") + std::to_string(filament_index_from_zero_based(extruder_idx)), max_tooltip_width);
 
         // draw filament id
         float gray = 0.299 * extruder_color.r() + 0.587 * extruder_color.g() + 0.114 * extruder_color.b();
@@ -1047,7 +1048,7 @@ void GLGizmoMmuSegmentation::render_filament_remap_ui(float window_width, float 
         #endif
 
         // overlay destination number with proper contrast calculation
-        std::string dst_txt = std::to_string(m_extruder_remap[src] + 1);
+        std::string dst_txt = std::to_string(filament_index_from_zero_based(static_cast<int>(m_extruder_remap[src])));
         float gray = 0.299f * dst_col.r() + 0.587f * dst_col.g() + 0.114f * dst_col.b();
         ImVec2 txt_sz = ImGui::CalcTextSize(dst_txt.c_str());
         ImVec2 pos = ImGui::GetItemRectMin();

--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -3274,7 +3274,7 @@ std::tuple<ImVec2, bool>  ImGuiWrapper::calculate_filament_group_text_size(const
 void ImGuiWrapper::filament_group(const std::string& filament_type, const char* hex_color, unsigned char filament_id, float align_width)
 {
     //ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
-    std::string id = std::to_string(static_cast<unsigned int> (filament_id + 1));
+    std::string id = std::to_string(filament_index_from_zero_based(static_cast<int>(filament_id)));
     ImDrawList* draw_list = ImGui::GetWindowDrawList();
     static ImTextureID transparent;
     ImVec2             text_size = ImGui::CalcTextSize(filament_type.c_str());

--- a/src/slic3r/GUI/ObjColorDialog.cpp
+++ b/src/slic3r/GUI/ObjColorDialog.cpp
@@ -409,7 +409,8 @@ ObjColorPanel::~ObjColorPanel() {
 void ObjColorPanel::msw_rescale()
 {
     for (unsigned int i = 0; i < m_extruder_icon_list.size(); ++i) {
-        auto bitmap = *get_extruder_color_icon(m_colours[i].GetAsString(wxC2S_HTML_SYNTAX).ToStdString(), std::to_string(i + 1), FromDIP(16), FromDIP(16));
+        const int display_index = filament_index_from_zero_based(static_cast<int>(i));
+        auto bitmap = *get_extruder_color_icon(m_colours[i].GetAsString(wxC2S_HTML_SYNTAX).ToStdString(), std::to_string(display_index), FromDIP(16), FromDIP(16));
         m_extruder_icon_list[i]->SetBitmap(bitmap);
     }
    /* for (unsigned int i = 0; i < m_color_cluster_icon_list.size(); ++i) {
@@ -530,7 +531,8 @@ wxBoxSizer *ObjColorPanel::create_extruder_icon_and_rgba_sizer(wxWindow *parent,
 {
     auto icon_sizer = new wxBoxSizer(wxHORIZONTAL);
     wxButton *icon       = new wxButton(parent, wxID_ANY, {}, wxDefaultPosition, ICON_SIZE, wxBORDER_NONE | wxBU_AUTODRAW);
-    icon->SetBitmap(*get_extruder_color_icon(color.GetAsString(wxC2S_HTML_SYNTAX).ToStdString(), std::to_string(id + 1), FromDIP(16), FromDIP(16)));
+    const int display_index = filament_index_from_zero_based(id);
+    icon->SetBitmap(*get_extruder_color_icon(color.GetAsString(wxC2S_HTML_SYNTAX).ToStdString(), std::to_string(display_index), FromDIP(16), FromDIP(16)));
     icon->SetCanFocus(false);
     m_extruder_icon_list.emplace_back(icon);
     icon_sizer->Add(icon, 0, wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 0); // wxALIGN_CENTER_VERTICAL | wxTOP | wxBOTTOM

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2277,7 +2277,7 @@ void Sidebar::init_filament_combo(PlaterPresetComboBox **combo, const int filame
     if ((filament_idx % 2) == 0) // Dont add right column item. this one create equal spacing on left, right & middle
         combo_and_btn_sizer->AddSpacer(FromDIP((filament_idx % 2) == 0 ? 12 : 3)); // Content Margin
 
-    (*combo)->clr_picker->SetLabel(wxString::Format("%d", filament_idx + 1));
+    (*combo)->clr_picker->SetLabel(wxString::Format("%d", filament_index_from_zero_based(filament_idx)));
     combo_and_btn_sizer->Add((*combo)->clr_picker, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(SidebarProps::ElementSpacing()) - FromDIP(2)); // ElementSpacing - 2 (from combo box))
     combo_and_btn_sizer->Add(*combo, 1, wxALL | wxEXPAND, FromDIP(2))->SetMinSize({-1, FromDIP(30)});
 

--- a/src/slic3r/GUI/Search.cpp
+++ b/src/slic3r/GUI/Search.cpp
@@ -13,6 +13,7 @@
 
 #include "libslic3r/PrintConfig.hpp"
 #include "libslic3r/PresetBundle.hpp"
+#include "GUI.hpp"
 #include "GUI_App.hpp"
 #include "Plater.hpp"
 #include "Tab.hpp"
@@ -338,7 +339,7 @@ static Option create_option(const std::string &opt_key, const wxString &label, P
     wxString category = gc.category;
     if (type == Preset::TYPE_PRINTER && category.Contains("Extruder ")) {
         std::string opt_idx = opt_key.substr(opt_key.find("#") + 1);
-        category            = wxString::Format("%s %d", "Extruder", atoi(opt_idx.c_str()) + 1);
+        category            = wxString::Format("%s %d", "Extruder", GUI::filament_index_from_zero_based(std::atoi(opt_idx.c_str())));
     }
 
     return Option{boost::nowide::widen(get_key(opt_key, type)),

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -4927,7 +4927,9 @@ if (is_marlin_flavor)
 
     // Orca: build missed extruder pages
     for (auto extruder_idx = m_extruders_count_old; extruder_idx < m_extruders_count; ++extruder_idx) {
-        const wxString& page_name = (m_extruders_count > 1) ? wxString::Format("Extruder %d", int(extruder_idx + 1)) : wxString::Format("Extruder");
+        const wxString& page_name = (m_extruders_count > 1)
+            ? wxString::Format("Extruder %d", filament_index_from_zero_based(static_cast<int>(extruder_idx)))
+            : wxString::Format("Extruder");
 
         //# build page
         //const wxString& page_name = wxString::Format("Extruder %d", int(extruder_idx + 1));
@@ -5057,7 +5059,7 @@ if (is_marlin_flavor)
         if (m_extruders_count == 1)
             first_extruder_title = wxString::Format("Extruder");
     } else if (m_extruders_count_old == 1) {
-        first_extruder_title = wxString::Format("Extruder %d", 1);
+        first_extruder_title = wxString::Format("Extruder %d", filament_index_from_zero_based(0));
     }
     auto & searcher = wxGetApp().sidebar().get_searcher();
     for (auto &group : m_pages[n_before_extruders]->m_optgroups) {


### PR DESCRIPTION
### Motivation

- UI shown filament/extruder numbers and numeric shortcuts were using hard-coded `+1` conversions, ignoring the `start_filament_index_at_0` setting and causing inconsistent 0-/1-based numbering across the interface.
- Make displayed indices and shortcut behaviour honor the configured filament index base while keeping internal logic zero-based.

### Description

- Replaced ad-hoc `+1` display conversions with `GUI::filament_index_from_zero_based(...)` or `start_filament_index_at_0()` checks in multiple UI areas to render filament/extruder numbers according to configuration (`src/slic3r/GUI/*`).
- Updated numeric shortcut mapping in `GLGizmoMmuSegmentation::on_number_key_down` to map keys using the configured index base so number keys select the expected filament.
- Switched display-only variables where appropriate (e.g. `extruder_index` vs `extruder_id`) and kept internal indices intact for lookups (only display and shortcuts are converted).
- Applied the numbering change to these components: `GCodeViewer` (tool/color labels, legends and settings text), `GLCanvas3D` (warning messages), `GLGizmoMmuSegmentation` (palette labels, remap overlays, shortcut handling), `ImGuiWrapper::filament_group` (filament id rendering), `ObjColorDialog` (extruder icons), `Plater` (sidebar filament picker labels), `Search` (printer tab/extruder category labels), and `Tab` (extruder page titles and first-extruder naming).

### Testing

- Project build (partial): `libslic3r_gui` and related GUI object files compiled successfully as part of a local build; the overall application link failed with `LNK1104: cannot open file '.../OrcaSlicer.dll'` so a full executable was not produced.
- No unit tests or other automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a90e34a448326a16257a63208135c)