### PR TITLE
Refresh printer tab when `start_filament_index_at_0` changes

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1541,6 +1541,10 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
         wxGetApp().sidebar().update_dynamic_filament_list();
         wxGetApp().sidebar().update_all_preset_comboboxes();
         wxGetApp().plater()->update();
+        if (m_type == Preset::TYPE_PRINTER) {
+            if (auto* printer_tab = dynamic_cast<TabPrinter*>(this))
+                printer_tab->build_unregular_pages();
+        }
     }
 
     if(opt_key == "purge_in_prime_tower")


### PR DESCRIPTION
### Motivation
- Changing the `start_filament_index_at_0` option required restarting OrcaSlicer for the printer settings UI to reflect the new extruder indexing, so the printer tab must be refreshed when this option changes.

### Description
- When handling `opt_key == "start_filament_index_at_0"` in `Tab::on_value_change`, call `build_unregular_pages()` on the `TabPrinter` instance (via `dynamic_cast`) after updating sidebar lists and the plater so extruder labels/pages update immediately; change applied in `src/slic3r/GUI/Tab.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a9f2e2db48326b3f0b53eb3060b88)