### PR TITLE
Refresh object list filament labels when index mode changes

### DIFF
--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -929,7 +929,7 @@ void MenuFactory::append_menu_item_change_extruder(wxMenu* menu)
             if (preset == nullptr) {
                 item_name = wxString::Format(_L("Filament %d"), display_index);
             } else {
-                item_name = wxString::Format("%d: %s", display_index, from_u8(preset->label(false)));
+                item_name = from_u8(preset->label(false));
             }
         }
 
@@ -2092,7 +2092,7 @@ void MenuFactory::append_menu_item_change_filament(wxMenu* menu)
             if (preset == nullptr) {
                 item_name = wxString::Format(_L("Filament %d"), display_index);
             } else {
-                item_name = wxString::Format("%d: %s", display_index, from_u8(preset->label(false)));
+                item_name = from_u8(preset->label(false));
             }
         }
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1540,7 +1540,12 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
     if (opt_key == "start_filament_index_at_0") {
         wxGetApp().sidebar().update_dynamic_filament_list();
         wxGetApp().sidebar().update_all_preset_comboboxes();
+        wxGetApp().obj_list()->update_objects_list_filament_column(wxGetApp().filaments_cnt());
         wxGetApp().plater()->update();
+        if (m_type == Preset::TYPE_PRINTER) {
+            if (auto* printer_tab = dynamic_cast<TabPrinter*>(this))
+                printer_tab->refresh_extruder_page_titles(boost::any_cast<bool>(value));
+        }
     }
 
     if(opt_key == "purge_in_prime_tower")
@@ -5052,15 +5057,17 @@ if (is_marlin_flavor)
     }
     // BBS. No extra extruder page for single physical extruder machine
     // # remove extra pages
-    auto &first_extruder_title = const_cast<wxString &>(m_pages[n_before_extruders]->title());
     if (m_extruders_count < m_extruders_count_old) {
-        m_pages.erase(	m_pages.begin() + n_before_extruders + m_extruders_count,
-                        m_pages.begin() + n_before_extruders + m_extruders_count_old);
-        if (m_extruders_count == 1)
-            first_extruder_title = wxString::Format("Extruder");
-    } else if (m_extruders_count_old == 1) {
-        first_extruder_title = wxString::Format("Extruder %d", filament_index_from_zero_based(0));
+        m_pages.erase(m_pages.begin() + n_before_extruders + m_extruders_count,
+                      m_pages.begin() + n_before_extruders + m_extruders_count_old);
     }
+    for (size_t extruder_idx = 0; extruder_idx < m_extruders_count; ++extruder_idx) {
+        wxString page_title = (m_extruders_count > 1)
+            ? wxString::Format("Extruder %d", filament_index_from_zero_based(static_cast<int>(extruder_idx)))
+            : wxString("Extruder");
+        m_pages[n_before_extruders + extruder_idx]->set_title(page_title);
+    }
+    const wxString& first_extruder_title = m_pages[n_before_extruders]->title();
     auto & searcher = wxGetApp().sidebar().get_searcher();
     for (auto &group : m_pages[n_before_extruders]->m_optgroups) {
         group->set_config_category_and_type(first_extruder_title, m_type);
@@ -5081,6 +5088,45 @@ if (is_marlin_flavor)
     reload_config();
 
     // apply searcher with current configuration
+    apply_searcher();
+}
+
+void TabPrinter::refresh_extruder_page_titles(bool start_at_zero)
+{
+    if (m_pages.empty() || m_extruders_count == 0)
+        return;
+
+    size_t first_extruder_page = m_pages.size();
+    for (size_t i = 0; i < m_pages.size(); ++i) {
+        const wxString& title = m_pages[i]->title();
+        if (title == "Extruder" || title.StartsWith("Extruder ")) {
+            first_extruder_page = i;
+            break;
+        }
+    }
+    if (first_extruder_page >= m_pages.size())
+        return;
+
+    for (size_t extruder_idx = 0; extruder_idx < m_extruders_count; ++extruder_idx) {
+        const size_t page_index = first_extruder_page + extruder_idx;
+        if (page_index >= m_pages.size())
+            break;
+
+        wxString page_title = (m_extruders_count > 1)
+            ? wxString::Format("Extruder %d", static_cast<int>(extruder_idx) + (start_at_zero ? 0 : 1))
+            : wxString("Extruder");
+        m_pages[page_index]->set_title(page_title);
+    }
+
+    const wxString& first_extruder_title = m_pages[first_extruder_page]->title();
+    auto& searcher = wxGetApp().sidebar().get_searcher();
+    for (auto& group : m_pages[first_extruder_page]->m_optgroups) {
+        group->set_config_category_and_type(first_extruder_title, m_type);
+        for (auto& opt : group->opt_map())
+            searcher.add_key(opt.first + "#0", m_type, group->title, first_extruder_title);
+    }
+
+    rebuild_page_tree();
     apply_searcher();
 }
 
@@ -7081,6 +7127,16 @@ void Page::reload_config()
 {
     for (auto group : m_optgroups)
         group->reload_config();
+}
+
+void Page::set_title(const wxString& title)
+{
+    if (m_title == title)
+        return;
+
+    m_title = title;
+    if (m_page_title)
+        m_page_title->SetLabel(_(m_title));
 }
 
 void Page::update_visibility(ConfigOptionMode mode, bool update_contolls_visibility)

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -86,6 +86,7 @@ public:
 	wxBoxSizer*	vsizer() const { return m_vsizer; }
 	wxWindow*	parent() const { return m_parent; }
 	const wxString&	title()	 const { return m_title; }
+	void		set_title(const wxString& title);
 	size_t		iconID() const { return m_iconID; }
 	void		set_config(DynamicPrintConfig* config_in) { m_config = config_in; }
 	void		reload_config();
@@ -640,6 +641,7 @@ public:
 	bool 		supports_printer_technology(const PrinterTechnology /* tech */) const override { return true; }
 
 	void		set_extruder_volume_type(int extruder_id, NozzleVolumeType type);
+	void		refresh_extruder_page_titles(bool start_at_zero);
 
 	wxSizer*	create_bed_shape_widget(wxWindow* parent);
 	void		cache_extruder_cnt(const DynamicPrintConfig* config = nullptr);


### PR DESCRIPTION
### Motivation
- The `start_filament_index_at_0` printer setting did not refresh all UI places immediately, requiring an app restart for the sidebar/object list to reflect the new filament numbering.
- Extruder page titles and search keys must update in-place when filament index origin is toggled so printer tab labels remain consistent.
- Filament preset labels in context menus included redundant numeric prefixes which clutter the UI.

### Description
- Refresh the object list filament column when `start_filament_index_at_0` changes by calling `wxGetApp().obj_list()->update_objects_list_filament_column(wxGetApp().filaments_cnt())` from `Tab::on_value_change`.
- Add `Page::set_title` to allow updating a page title at runtime and use it to update visible page labels instead of const-casting titles.
- Implement `TabPrinter::refresh_extruder_page_titles(bool)` to update extruder page titles, optgroup categories and search keys, and then call `rebuild_page_tree()` and `apply_searcher()` to apply changes in-place.
- Remove numeric index prefixes (e.g. `"0: "`, `"1: "`) from filament menu entries in `MenuFactory` to display preset labels directly.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a9f2e2db48326b3f0b53eb3060b88)