### PR TITLE
Fix object sidebar filament labels for zero-based indexing

### DIFF
--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -929,7 +929,7 @@ void MenuFactory::append_menu_item_change_extruder(wxMenu* menu)
             if (preset == nullptr) {
                 item_name = wxString::Format(_L("Filament %d"), display_index);
             } else {
-                item_name = wxString::Format("%d: %s", display_index, from_u8(preset->label(false)));
+                item_name = from_u8(preset->label(false));
             }
         }
 
@@ -2092,7 +2092,7 @@ void MenuFactory::append_menu_item_change_filament(wxMenu* menu)
             if (preset == nullptr) {
                 item_name = wxString::Format(_L("Filament %d"), display_index);
             } else {
-                item_name = wxString::Format("%d: %s", display_index, from_u8(preset->label(false)));
+                item_name = from_u8(preset->label(false));
             }
         }
 

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -81,7 +81,7 @@ static int filaments_count()
 static wxString format_filament_index_for_display(int extruder_id)
 {
     if (extruder_id <= 0)
-        return wxString::Format("%d", extruder_id);
+        return _L("default");
 
     return wxString::Format("%d", filament_index_from_one_based(extruder_id));
 }

--- a/src/slic3r/GUI/ObjectDataViewModel.cpp
+++ b/src/slic3r/GUI/ObjectDataViewModel.cpp
@@ -48,7 +48,7 @@ static constexpr char LockIcon[]            = "cut_";
 static wxString format_filament_index_for_display(int extruder_id)
 {
     if (extruder_id <= 0)
-        return wxString::Format("%d", extruder_id);
+        return _L("default");
 
     return wxString::Format("%d", filament_index_from_one_based(extruder_id));
 }
@@ -350,7 +350,8 @@ bool ObjectDataViewModelNode::SetValue(const wxVariant& variant, unsigned col)
         DataViewBitmapText data;
         data << variant;
         m_extruder_bmp = data.GetBitmap();
-        m_extruder = data.GetText() == "0" ? _(L("default")) : data.GetText();
+        const wxString text = data.GetText();
+        m_extruder = (text == "0" && !start_filament_index_at_0()) ? _(L("default")) : text;
         return true; }
     // BBS
     case colSupportPaint:
@@ -408,7 +409,11 @@ void ObjectDataViewModelNode::UpdateExtruderAndColorIcon(wxString extruder /*= "
 
     // update color icon
     size_t extruder_idx = atoi(extruder.c_str());
-    if (extruder_idx == 0) {
+    const wxString default_label = _(L("default"));
+    if (start_filament_index_at_0() && extruder_idx == 0 && extruder != default_label) {
+        extruder_idx = 1;
+    }
+    if (extruder_idx == 0 && (!start_filament_index_at_0() || extruder == default_label)) {
         if (m_type & itObject);
         else if (m_type & itVolume && m_volume_type == ModelVolumeType::MODEL_PART) {
             extruder_idx = atoi(m_parent->GetExtruder().c_str());

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1540,7 +1540,12 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
     if (opt_key == "start_filament_index_at_0") {
         wxGetApp().sidebar().update_dynamic_filament_list();
         wxGetApp().sidebar().update_all_preset_comboboxes();
+        wxGetApp().obj_list()->update_objects_list_filament_column(wxGetApp().filaments_cnt());
         wxGetApp().plater()->update();
+        if (m_type == Preset::TYPE_PRINTER) {
+            if (auto* printer_tab = dynamic_cast<TabPrinter*>(this))
+                printer_tab->refresh_extruder_page_titles(boost::any_cast<bool>(value));
+        }
     }
 
     if(opt_key == "purge_in_prime_tower")
@@ -5052,15 +5057,17 @@ if (is_marlin_flavor)
     }
     // BBS. No extra extruder page for single physical extruder machine
     // # remove extra pages
-    auto &first_extruder_title = const_cast<wxString &>(m_pages[n_before_extruders]->title());
     if (m_extruders_count < m_extruders_count_old) {
-        m_pages.erase(	m_pages.begin() + n_before_extruders + m_extruders_count,
-                        m_pages.begin() + n_before_extruders + m_extruders_count_old);
-        if (m_extruders_count == 1)
-            first_extruder_title = wxString::Format("Extruder");
-    } else if (m_extruders_count_old == 1) {
-        first_extruder_title = wxString::Format("Extruder %d", filament_index_from_zero_based(0));
+        m_pages.erase(m_pages.begin() + n_before_extruders + m_extruders_count,
+                      m_pages.begin() + n_before_extruders + m_extruders_count_old);
     }
+    for (size_t extruder_idx = 0; extruder_idx < m_extruders_count; ++extruder_idx) {
+        wxString page_title = (m_extruders_count > 1)
+            ? wxString::Format("Extruder %d", filament_index_from_zero_based(static_cast<int>(extruder_idx)))
+            : wxString("Extruder");
+        m_pages[n_before_extruders + extruder_idx]->set_title(page_title);
+    }
+    const wxString& first_extruder_title = m_pages[n_before_extruders]->title();
     auto & searcher = wxGetApp().sidebar().get_searcher();
     for (auto &group : m_pages[n_before_extruders]->m_optgroups) {
         group->set_config_category_and_type(first_extruder_title, m_type);
@@ -5081,6 +5088,45 @@ if (is_marlin_flavor)
     reload_config();
 
     // apply searcher with current configuration
+    apply_searcher();
+}
+
+void TabPrinter::refresh_extruder_page_titles(bool start_at_zero)
+{
+    if (m_pages.empty() || m_extruders_count == 0)
+        return;
+
+    size_t first_extruder_page = m_pages.size();
+    for (size_t i = 0; i < m_pages.size(); ++i) {
+        const wxString& title = m_pages[i]->title();
+        if (title == "Extruder" || title.StartsWith("Extruder ")) {
+            first_extruder_page = i;
+            break;
+        }
+    }
+    if (first_extruder_page >= m_pages.size())
+        return;
+
+    for (size_t extruder_idx = 0; extruder_idx < m_extruders_count; ++extruder_idx) {
+        const size_t page_index = first_extruder_page + extruder_idx;
+        if (page_index >= m_pages.size())
+            break;
+
+        wxString page_title = (m_extruders_count > 1)
+            ? wxString::Format("Extruder %d", static_cast<int>(extruder_idx) + (start_at_zero ? 0 : 1))
+            : wxString("Extruder");
+        m_pages[page_index]->set_title(page_title);
+    }
+
+    const wxString& first_extruder_title = m_pages[first_extruder_page]->title();
+    auto& searcher = wxGetApp().sidebar().get_searcher();
+    for (auto& group : m_pages[first_extruder_page]->m_optgroups) {
+        group->set_config_category_and_type(first_extruder_title, m_type);
+        for (auto& opt : group->opt_map())
+            searcher.add_key(opt.first + "#0", m_type, group->title, first_extruder_title);
+    }
+
+    rebuild_page_tree();
     apply_searcher();
 }
 
@@ -7081,6 +7127,16 @@ void Page::reload_config()
 {
     for (auto group : m_optgroups)
         group->reload_config();
+}
+
+void Page::set_title(const wxString& title)
+{
+    if (m_title == title)
+        return;
+
+    m_title = title;
+    if (m_page_title)
+        m_page_title->SetLabel(_(m_title));
 }
 
 void Page::update_visibility(ConfigOptionMode mode, bool update_contolls_visibility)

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -86,6 +86,7 @@ public:
 	wxBoxSizer*	vsizer() const { return m_vsizer; }
 	wxWindow*	parent() const { return m_parent; }
 	const wxString&	title()	 const { return m_title; }
+	void		set_title(const wxString& title);
 	size_t		iconID() const { return m_iconID; }
 	void		set_config(DynamicPrintConfig* config_in) { m_config = config_in; }
 	void		reload_config();
@@ -640,6 +641,7 @@ public:
 	bool 		supports_printer_technology(const PrinterTechnology /* tech */) const override { return true; }
 
 	void		set_extruder_volume_type(int extruder_id, NozzleVolumeType type);
+	void		refresh_extruder_page_titles(bool start_at_zero);
 
 	wxSizer*	create_bed_shape_widget(wxWindow* parent);
 	void		cache_extruder_cnt(const DynamicPrintConfig* config = nullptr);


### PR DESCRIPTION
### Motivation
- The object list and extruder UI became ambiguous when `start_filament_index_at_0` is enabled because a display value of `0` was treated the same as the unassigned/default label, causing sidebar numbering and color icons to not correspond to configured numbering.
- Extruder page titles and search keys must reflect the configured origin so printer tab labels and search behaviour stay consistent when toggling the index origin.

### Description
- Normalize filament label formatting to show the localized `"default"` label for unassigned extruders by changing `format_filament_index_for_display` in `ObjectDataViewModel.cpp` and `GUI_ObjectList.cpp` to return `_L("default")` when `extruder_id <= 0`.
- In `ObjectDataViewModel::SetValue` and `UpdateExtruderAndColorIcon` adjust logic to avoid treating the literal display string `"0"` as the default when `start_filament_index_at_0()` is enabled, and remap the index appropriately for color icon lookup.
- Update `Tab::on_value_change` to refresh the object list filament column and plater view when `start_filament_index_at_0` changes, and add `TabPrinter::refresh_extruder_page_titles` plus `Page::set_title` to update extruder page titles, optgroup categories and search keys in-place, calling `rebuild_page_tree()` and `apply_searcher()`.
- Remove numeric index prefixes from filament menu entries in `GUI_Factories.cpp` so preset labels are shown directly without redundant numeric prefixes.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a9f2e2db48326b3f0b53eb3060b88)