### PR TITLE
Fix filament indices in object list

### DIFF
--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -83,7 +83,7 @@ static wxString format_filament_index_for_display(int extruder_id)
     if (extruder_id <= 0)
         return wxString::Format("%d", extruder_id);
 
-    return wxString::Format("%d", filament_index_from_one_based(extruder_id));
+    return wxString::Format("%d", filament_index_from_zero_based(extruder_id));
 }
 
 static void take_snapshot(const std::string& snapshot_name)

--- a/src/slic3r/GUI/ObjectDataViewModel.cpp
+++ b/src/slic3r/GUI/ObjectDataViewModel.cpp
@@ -50,7 +50,7 @@ static wxString format_filament_index_for_display(int extruder_id)
     if (extruder_id <= 0)
         return wxString::Format("%d", extruder_id);
 
-    return wxString::Format("%d", filament_index_from_one_based(extruder_id));
+    return wxString::Format("%d", filament_index_from_zero_based(extruder_id));
 }
 
 ObjectDataViewModelNode::ObjectDataViewModelNode(PartPlate* part_plate, wxString name) :
@@ -1764,7 +1764,10 @@ int ObjectDataViewModel::GetExtruderNumber(const wxDataViewItem& item) const
         return 0;
 
     if (start_filament_index_at_0())
-        return static_cast<int>(value) + 1;
+        return static_cast<int>(value);
+
+    if (value > 0)
+        return static_cast<int>(value) - 1;
 
     return static_cast<int>(value);
 }


### PR DESCRIPTION
### Motivation
- Fix incorrect filament mapping in the Objects sidebar when `start_filament_index_at_0` is enabled that caused objects to show wrong filament numbers (off-by-one display/parsing mismatch).

### Description
- Use `filament_index_from_zero_based` for filament labels in `src/slic3r/GUI/ObjectDataViewModel.cpp` and `src/slic3r/GUI/GUI_ObjectList.cpp` instead of the one-based formatter.
- Update `ObjectDataViewModel::GetExtruderNumber` parsing so the displayed extruder string is converted back to the correct zero-based config value when `start_filament_index_at_0()` is disabled and preserved when enabled.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b0ef1bf108326bb6a507077a39337)