### PR TITLE
Restore raw filament indices in object list to fix mapping mismatch

### DIFF
--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -83,7 +83,7 @@ static wxString format_filament_index_for_display(int extruder_id)
     if (extruder_id <= 0)
         return wxString::Format("%d", extruder_id);
 
-    return wxString::Format("%d", filament_index_from_one_based(extruder_id));
+    return wxString::Format("%d", extruder_id);
 }
 
 static void take_snapshot(const std::string& snapshot_name)

--- a/src/slic3r/GUI/ObjectDataViewModel.cpp
+++ b/src/slic3r/GUI/ObjectDataViewModel.cpp
@@ -50,7 +50,7 @@ static wxString format_filament_index_for_display(int extruder_id)
     if (extruder_id <= 0)
         return wxString::Format("%d", extruder_id);
 
-    return wxString::Format("%d", filament_index_from_one_based(extruder_id));
+    return wxString::Format("%d", extruder_id);
 }
 
 ObjectDataViewModelNode::ObjectDataViewModelNode(PartPlate* part_plate, wxString name) :
@@ -1762,9 +1762,6 @@ int ObjectDataViewModel::GetExtruderNumber(const wxDataViewItem& item) const
     const long value           = std::strtol(extruder.c_str(), &end, 10);
     if (end == extruder.c_str() || *end != '\0')
         return 0;
-
-    if (start_filament_index_at_0())
-        return static_cast<int>(value) + 1;
 
     return static_cast<int>(value);
 }


### PR DESCRIPTION
### Motivation
- Previous index-base conversions caused objects to display and parse filament numbers inconsistently when toggling `start_filament_index_at_0`, producing off-by-one and color-mapping errors in the Objects sidebar.
- Restore a consistent representation that matches the stored extruder index in the config so displayed labels and parsed values align.

### Description
- Replace use of base-conversion helpers with direct formatting by returning the raw `extruder_id` in `format_filament_index_for_display` in `src/slic3r/GUI/GUI_ObjectList.cpp` and `src/slic3r/GUI/ObjectDataViewModel.cpp`.
- Simplify `ObjectDataViewModel::GetExtruderNumber` to parse and return the numeric value from `node->m_extruder` without adding or subtracting offsets related to `start_filament_index_at_0`.
- These changes remove asymmetric display/parse conversions that caused objects to be mapped to the wrong filament index.

### Testing
- No automated tests were run for this change.
- No build/test output was produced during the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b0ef1bf108326bb6a507077a39337)