### PR TITLE
Rename filament indexing setting to `zero_based_filament_indexing`

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1024,7 +1024,7 @@ static std::vector<std::string> s_Preset_printer_options {
     "use_relative_e_distances", "extruder_type", "use_firmware_retraction", "printer_notes",
     "grab_length", "support_object_skip_flush", "physical_extruder_map",
     "cooling_tube_retraction",
-    "cooling_tube_length", "high_current_on_filament_swap", "parking_pos_retraction", "extra_loading_move", "start_filament_index_at_0",
+    "cooling_tube_length", "high_current_on_filament_swap", "parking_pos_retraction", "extra_loading_move", "zero_based_filament_indexing",
     "purge_in_prime_tower", "enable_filament_ramming",
     "z_offset",
     "disable_m73", "preferred_orientation", "emit_machine_limits_to_gcode", "pellet_modded_printer", "support_multi_bed_types", "default_bed_type", "bed_mesh_min","bed_mesh_max","bed_mesh_probe_distance", "adaptive_bed_mesh_margin", "enable_long_retraction_when_cut","long_retractions_when_cut","retraction_distances_when_cut",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4428,9 +4428,9 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(-2.));
 
-    def          = this->add("start_filament_index_at_0", coBool);
-    def->label   = L("Start filament index at 0");
-    def->tooltip = L("When enabled, filament/extruder indices in OrcaSlicer's interface are treated as 0-based (0..N-1) instead of 1-based (1..N).");
+    def          = this->add("zero_based_filament_indexing", coBool);
+    def->label   = L("0-based_filament_indexing");
+    def->tooltip = L("When enabled, 0-based filament indexing is used in OrcaSlicer's interface (0..N-1 instead of 1..N).");
     def->mode    = comAdvanced;
     def->set_default_value(new ConfigOptionBool(true));
 

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1385,7 +1385,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionBool,                purge_in_prime_tower))
     ((ConfigOptionBool,                enable_filament_ramming))
     ((ConfigOptionBool,                support_multi_bed_types))
-    ((ConfigOptionBool,                start_filament_index_at_0))
+    ((ConfigOptionBool,                zero_based_filament_indexing))
 
 
     // Small Area Infill Flow Compensation

--- a/src/slic3r/GUI/GUI.cpp
+++ b/src/slic3r/GUI/GUI.cpp
@@ -102,25 +102,25 @@ const std::string& shortkey_alt_prefix()
 	return str;
 }
 
-bool start_filament_index_at_0()
+bool zero_based_filament_indexing()
 {
     const auto* preset_bundle = wxGetApp().preset_bundle;
     if (!preset_bundle)
         return false;
 
     const auto& config = preset_bundle->printers.get_edited_preset().config;
-    const auto* opt = config.option<ConfigOptionBool>("start_filament_index_at_0");
+    const auto* opt = config.option<ConfigOptionBool>("zero_based_filament_indexing");
     return opt != nullptr && opt->value;
 }
 
 int filament_index_from_zero_based(int index)
 {
-    return index + (start_filament_index_at_0() ? 0 : 1);
+    return index + (zero_based_filament_indexing() ? 0 : 1);
 }
 
 int filament_index_from_one_based(int index)
 {
-    return start_filament_index_at_0() ? index - 1 : index;
+    return zero_based_filament_indexing() ? index - 1 : index;
 }
 
 // opt_index = 0, by the reason of zero-index in ConfigOptionVector by default (in case only one element)

--- a/src/slic3r/GUI/GUI.hpp
+++ b/src/slic3r/GUI/GUI.hpp
@@ -32,7 +32,7 @@ void break_to_debugger();
 extern const std::string& shortkey_ctrl_prefix();
 extern const std::string& shortkey_alt_prefix();
 
-bool start_filament_index_at_0();
+bool zero_based_filament_indexing();
 int filament_index_from_zero_based(int index);
 int filament_index_from_one_based(int index);
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
@@ -192,7 +192,7 @@ void GLGizmoMmuSegmentation::data_changed(bool is_serializing)
 // BBS
 bool GLGizmoMmuSegmentation::on_number_key_down(int number)
 {
-    int extruder_idx = start_filament_index_at_0() ? number : number - 1;
+    int extruder_idx = zero_based_filament_indexing() ? number : number - 1;
     if (extruder_idx < m_extruders_colors.size() && extruder_idx >= 0)
         m_selected_extruder_idx = extruder_idx;
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -842,7 +842,7 @@ struct DynamicFilamentList1Based : DynamicFilamentList
         long n = 0;
         if(!value.ToLong(&n))
             return -1;
-        if (!start_filament_index_at_0())
+        if (!zero_based_filament_indexing())
             --n;
         return (n >= 0 && n <= static_cast<long>(items.size())) ? int(n) : -1;
     }

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1537,7 +1537,7 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
         wxGetApp().get_tab(Preset::TYPE_PRINT)->update();
     }
 
-    if (opt_key == "start_filament_index_at_0") {
+    if (opt_key == "zero_based_filament_indexing") {
         wxGetApp().sidebar().update_dynamic_filament_list();
         wxGetApp().sidebar().update_all_preset_comboboxes();
         wxGetApp().obj_list()->update_objects_list_filament_column(wxGetApp().filaments_cnt());
@@ -4926,7 +4926,7 @@ if (is_marlin_flavor)
         optgroup->append_single_option_line("machine_load_filament_time", "printer_multimaterial_advanced#filament-load-time");
         optgroup->append_single_option_line("machine_unload_filament_time", "printer_multimaterial_advanced#filament-unload-time");
         optgroup->append_single_option_line("machine_tool_change_time", "printer_multimaterial_advanced#tool-change-time");
-        optgroup->append_single_option_line("start_filament_index_at_0", "printer_multimaterial_advanced#start-filament-index-at-0");
+        optgroup->append_single_option_line("zero_based_filament_indexing", "printer_multimaterial_advanced#zero-based-filament-indexing");
         m_pages.insert(m_pages.end() - n_after_single_extruder_MM, page);
     }
 


### PR DESCRIPTION
### Motivation
- Clarify and standardize the setting name for filament/extruder indexing by switching from `start_filament_index_at_0` to a C++-friendly `zero_based_filament_indexing` key and UI label.
- Ensure all code paths and helpers consistently refer to the new name so behavior is unambiguous across the GUI and config layers.

### Description
- Renamed the config key from `start_filament_index_at_0` to `zero_based_filament_indexing` in `src/libslic3r/PrintConfig.cpp` and `src/libslic3r/PrintConfig.hpp`, and updated the label to `L("0-based_filament_indexing")` and tooltip to describe 0-based indexing.
- Updated presets to include `zero_based_filament_indexing` in `src/libslic3r/Preset.cpp`.
- Replaced helper and usage sites: renamed `start_filament_index_at_0()` to `zero_based_filament_indexing()` and updated callers in `src/slic3r/GUI/GUI.hpp` and `src/slic3r/GUI/GUI.cpp`.
- Updated all references in GUI code that depended on the old key, including `src/slic3r/GUI/Tab.cpp`, `src/slic3r/GUI/Plater.cpp`, and `src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp` to use the new key/function and to update option group identifiers.

### Testing
- No automated tests were run for this change.
- Repository was searched to verify occurrences of the old key were replaced with the new `zero_based_filament_indexing` identifier and UI labels were updated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b161f209c83269081c6fcaf24f13b)