### PR TITLE
Fix extruder index lookup for error text

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -9492,7 +9492,7 @@ void GLCanvas3D::_set_warning_notification(EWarning warning, bool state)
             if (error_iter != m_gcode_viewer.m_gcode_check_result.print_area_error_infos.begin()) {
                 text += "\n";
             }
-            int extruder_id = filament_index_from_zero_based(error_iter->first);
+            const int extruder_index = error_iter->first;
             std::string filaments;
             std::vector<int> slice_error_object_idxs;
             for (size_t i = 0; i < error_iter->second.size(); ++i) {


### PR DESCRIPTION
### Motivation
- Fix a compile error where `extruder_index` was referenced before being declared in `src/slic3r/GUI/GLCanvas3D.cpp`, which caused the build to fail when processing multi-extruder printable error messages.

### Description
- Add `const int extruder_index = error_iter->first;` in the `EWarning::MultiExtruderPrintableError` handler in `src/slic3r/GUI/GLCanvas3D.cpp` so `extruder_name_list[extruder_index]` is resolved correctly.

### Testing
- No automated tests were run (no `ctest`/CI executed) as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b3ef102f483269b1b8a61ce4eadb0)