### PR TITLE
Fix filament index bounds check

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -844,7 +844,7 @@ struct DynamicFilamentList1Based : DynamicFilamentList
             return -1;
         if (!zero_based_filament_indexing())
             --n;
-        return (n >= 0 && n <= static_cast<long>(items.size())) ? int(n) : -1;
+        return (n >= 0 && n < static_cast<long>(items.size())) ? int(n) : -1;
     }
     void update(bool force = false)
     {


### PR DESCRIPTION
### Motivation

- Fix an off-by-one error in `index_of` for the filament list so an input equal to `items.size()` is treated as out-of-range instead of accepted.

### Description

- Replace `<=` with `<` in the bounds check inside `DynamicFilamentList1Based::index_of` in `src/slic3r/GUI/Plater.cpp` to enforce the proper upper bound.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b38bace0c832684e871d61e18fb6e)