### PR TITLE
Respect zero-based filament indexing for plater number-key shortcuts

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -1209,7 +1209,6 @@ GLCanvas3D::GLCanvas3D(wxGLCanvas* canvas, Bed3D &bed)
         m_retina_helper.reset(new RetinaHelper(canvas));
 #endif // ENABLE_RETINA_GL
     }
-    m_timer_set_color.Bind(wxEVT_TIMER, &GLCanvas3D::on_set_color_timer, this);
     load_arrange_settings();
 
     m_selection.set_volumes(&m_volumes.volumes);
@@ -1219,8 +1218,12 @@ GLCanvas3D::GLCanvas3D(wxGLCanvas* canvas, Bed3D &bed)
     // FIXME: maybe should be using GUI::shortkey_alt_prefix() or equivalent?
     m_assembly_view_desc["part_selection_caption"]   = _L("Alt+") + _L("Left mouse button");
     m_assembly_view_desc["part_selection"]           = _L("part selection");
-    m_assembly_view_desc["number_key_caption"]       = "1~16 " + _L("number keys");
-    m_assembly_view_desc["number_key"]       = _L("number keys can quickly change the color of objects");
+    m_assembly_view_desc["number_key_caption"]       = "0-9 " + _L("number keys");
+    if (GUI::zero_based_filament_indexing()) {
+        m_assembly_view_desc["number_key"] = _L("number keys can quickly change the color of objects (0 selects filament 0)");
+    } else {
+        m_assembly_view_desc["number_key"] = _L("number keys can quickly change the color of objects (0 selects filament 10)");
+    }
 }
 
 GLCanvas3D::~GLCanvas3D()
@@ -3397,14 +3400,8 @@ void GLCanvas3D::on_char(wxKeyEvent& evt)
             break;
         }
 
-        // BBS: use keypad to change extruder
-        case '1': {
-            if (!m_timer_set_color.IsRunning()) {
-                m_timer_set_color.StartOnce(500);
-                break;
-            }
-        }
-        case '0':   //Color logic for material 10
+        case '0':
+        case '1':
         case '2':
         case '3':
         case '4':
@@ -3413,12 +3410,11 @@ void GLCanvas3D::on_char(wxKeyEvent& evt)
         case '7':
         case '8':
         case '9': {
-            if (m_timer_set_color.IsRunning()) {
-                if (keyCode < '7')  keyCode += 10;
-                m_timer_set_color.Stop();
+            if (m_gizmos.get_current_type() != GLGizmosManager::MmSegmentation) {
+                const bool zero_based = GUI::zero_based_filament_indexing();
+                const int extruder_id = zero_based ? (keyCode - '0') : (keyCode == '0' ? 10 : keyCode - '0');
+                obj_list->set_extruder_for_selected_items(extruder_id);
             }
-            if (m_gizmos.get_current_type() != GLGizmosManager::MmSegmentation)
-                obj_list->set_extruder_for_selected_items(keyCode - '0');
             break;
         }
 
@@ -3955,15 +3951,6 @@ void GLCanvas3D::on_render_timer(wxTimerEvent& evt)
     // m_dirty = true;
     // wxWakeUpIdle();
 }
-
-void GLCanvas3D::on_set_color_timer(wxTimerEvent& evt)
-{
-    auto obj_list = wxGetApp().obj_list();
-    if (m_gizmos.get_current_type() != GLGizmosManager::MmSegmentation)
-        obj_list->set_extruder_for_selected_items(1);
-    m_timer_set_color.Stop();
-}
-
 
 void GLCanvas3D::schedule_extra_frame(int miliseconds)
 {

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -528,7 +528,6 @@ private:
     unsigned int m_last_w, m_last_h;
     bool m_in_render;
     wxTimer m_timer;
-    wxTimer m_timer_set_color;
     LayersEditing m_layers_editing;
     Mouse m_mouse;
     GLGizmosManager m_gizmos;
@@ -1027,7 +1026,6 @@ public:
     void on_mouse_wheel(wxMouseEvent& evt);
     void on_timer(wxTimerEvent& evt);
     void on_render_timer(wxTimerEvent& evt);
-    void on_set_color_timer(wxTimerEvent& evt);
     void on_mouse(wxMouseEvent& evt);
     void on_gesture(wxGestureEvent& evt);
     void on_paint(wxPaintEvent& evt);


### PR DESCRIPTION
### Motivation
- Make the plater color/filament number shortcuts behave consistently with the global `zero_based_filament_indexing` setting so that number keys map to the expected filament indices.
- Remove the previous timer-based fallback behavior and simplify the number-key handling logic.

### Description
- Updated the UI help text in `GLCanvas3D` to reflect the active numbering scheme by using `GUI::zero_based_filament_indexing()` when setting `m_assembly_view_desc["number_key"]`.
- Changed number-key handling in `GLCanvas3D::on_char` so keys `'0'`–`'9'` map to filament indices based on `zero_based_filament_indexing()` (when enabled `0` → filament 0, otherwise keep `0` → filament 10 and `1`–`9` → 1–9).
- Removed the old timer-based fallback logic and the `m_timer_set_color` timer and its handler, simplifying the key handling flow.
- Cleaned up corresponding declarations in `GLCanvas3D.hpp` to remove the now-unused timer and handler.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b4a7ecad0832690bbd0d6fee3cb6a)