### PR TITLE
Adjust filament numeric shortcuts to respect zero-based indexing

### DIFF
--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -1754,13 +1754,18 @@ void ObjectList::key_event(wxKeyEvent& event)
     else if (event.GetUnicodeKey() == 'p')
         toggle_printable_state();
     else if (filaments_count() > 1) {
-        std::vector<wxChar> numbers = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
         wxChar key_char = event.GetUnicodeKey();
-        if (std::find(numbers.begin(), numbers.end(), key_char) != numbers.end()) {
-            long extruder_number;
-            if (wxNumberFormatter::FromString(wxString(key_char), &extruder_number) &&
-                filaments_count() >= extruder_number)
-                set_extruder_for_selected_items(int(extruder_number));
+        if (key_char >= '0' && key_char <= '9') {
+            const int digit = key_char - '0';
+            int extruder_number = digit;
+            if (zero_based_filament_indexing()) {
+                extruder_number = digit + 1;
+            } else if (digit == 0) {
+                extruder_number = 10;
+            }
+
+            if (extruder_number > 0 && filaments_count() >= extruder_number)
+                set_extruder_for_selected_items(extruder_number);
         }
         else
             event.Skip();


### PR DESCRIPTION
### Motivation
- Ensure numeric keyboard shortcuts for selecting filaments follow the `zero_based_filament_indexing` option and keep the legacy 0→10 mapping in one-based mode.

### Description
- Replace the previous numeric parsing with direct digit handling in `ObjectList::key_event` and map pressed digits to the internal extruder IDs so that when `zero_based_filament_indexing()` is enabled the key is offset appropriately, and when disabled the digit `'0'` maps to filament 10; bounds are checked before calling `set_extruder_for_selected_items`.

### Testing
- No automated tests were executed (`ctest` not run) for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ec6dd03c88326a89306346d05b2d5)