### PR TITLE
Fix numeric filament shortcuts for zero-based indexing and handle '1' timer correctly

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -3399,7 +3399,7 @@ void GLCanvas3D::on_char(wxKeyEvent& evt)
 
         // BBS: use keypad to change extruder
         case '1': {
-            if (!m_timer_set_color.IsRunning()) {
+            if (!zero_based_filament_indexing() && !m_timer_set_color.IsRunning()) {
                 m_timer_set_color.StartOnce(500);
                 break;
             }
@@ -3414,11 +3414,16 @@ void GLCanvas3D::on_char(wxKeyEvent& evt)
         case '8':
         case '9': {
             if (m_timer_set_color.IsRunning()) {
-                if (keyCode < '7')  keyCode += 10;
+                if (keyCode < '7')
+                    keyCode += 10;
                 m_timer_set_color.Stop();
             }
-            if (m_gizmos.get_current_type() != GLGizmosManager::MmSegmentation)
-                obj_list->set_extruder_for_selected_items(keyCode - '0');
+            if (m_gizmos.get_current_type() != GLGizmosManager::MmSegmentation) {
+                const int shortcut_number = keyCode - '0';
+                const int extruder_number = filament_shortcut_to_extruder(shortcut_number);
+                if (extruder_number > 0)
+                    obj_list->set_extruder_for_selected_items(extruder_number);
+            }
             break;
         }
 

--- a/src/slic3r/GUI/GUI.cpp
+++ b/src/slic3r/GUI/GUI.cpp
@@ -123,6 +123,17 @@ int filament_index_from_one_based(int index)
     return zero_based_filament_indexing() ? index - 1 : index;
 }
 
+int filament_shortcut_to_extruder(int shortcut_number)
+{
+    if (shortcut_number < 0)
+        return shortcut_number;
+
+    if (zero_based_filament_indexing())
+        return shortcut_number + 1;
+
+    return shortcut_number == 0 ? 10 : shortcut_number;
+}
+
 // opt_index = 0, by the reason of zero-index in ConfigOptionVector by default (in case only one element)
 void change_opt_value(DynamicPrintConfig& config, const t_config_option_key& opt_key, const boost::any& value, int opt_index /*= 0*/)
 {

--- a/src/slic3r/GUI/GUI.hpp
+++ b/src/slic3r/GUI/GUI.hpp
@@ -35,6 +35,7 @@ extern const std::string& shortkey_alt_prefix();
 bool zero_based_filament_indexing();
 int filament_index_from_zero_based(int index);
 int filament_index_from_one_based(int index);
+int filament_shortcut_to_extruder(int shortcut_number);
 
 extern AppConfig* get_app_config();
 

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -4,6 +4,7 @@
 #include "GUI_Factories.hpp"
 //#include "GUI_ObjectLayers.hpp"
 #include "GUI_App.hpp"
+#include "GUI.hpp"
 #include "I18N.hpp"
 #include "Plater.hpp"
 #include "BitmapComboBox.hpp"
@@ -1754,13 +1755,12 @@ void ObjectList::key_event(wxKeyEvent& event)
     else if (event.GetUnicodeKey() == 'p')
         toggle_printable_state();
     else if (filaments_count() > 1) {
-        std::vector<wxChar> numbers = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
         wxChar key_char = event.GetUnicodeKey();
-        if (std::find(numbers.begin(), numbers.end(), key_char) != numbers.end()) {
-            long extruder_number;
-            if (wxNumberFormatter::FromString(wxString(key_char), &extruder_number) &&
-                filaments_count() >= extruder_number)
-                set_extruder_for_selected_items(int(extruder_number));
+        if (key_char >= '0' && key_char <= '9') {
+            const int digit = key_char - '0';
+            const int extruder_number = filament_shortcut_to_extruder(digit);
+            if (extruder_number > 0 && filaments_count() >= extruder_number)
+                set_extruder_for_selected_items(extruder_number);
         }
         else
             event.Skip();

--- a/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
@@ -998,7 +998,7 @@ bool GLGizmosManager::on_key(wxKeyEvent& evt)
                     keyCode = keyCode- WXK_NUMPAD0+'0';
                 }
                 if (keyCode >= '0' && keyCode <= '9') {
-                    if (keyCode == '1' && !m_timer_set_color.IsRunning()) {
+                    if (keyCode == '1' && !zero_based_filament_indexing() && !m_timer_set_color.IsRunning()) {
                         m_timer_set_color.StartOnce(500);
                         processed = true;
                     }


### PR DESCRIPTION
### Motivation
- Ensure numeric-key shortcuts map to extruders consistently when `zero_based_filament_indexing()` is enabled and avoid the two-digit timer interfering with `1`.

### Description
- Add `filament_shortcut_to_extruder(int)` in `GUI.cpp` and declare it in `GUI.hpp` to convert a pressed digit to the internal extruder number while honoring zero-based indexing.
- Replace ad-hoc digit handling in `GLCanvas3D.cpp` and `GUI_ObjectList.cpp` to use `filament_shortcut_to_extruder()` and use the returned extruder number when setting selected items' extruder.
- Skip the two-digit `m_timer_set_color` behavior for key `'1'` when `zero_based_filament_indexing()` is enabled in both `GLCanvas3D.cpp` and `Gizmos/GLGizmosManager.cpp` so `'1'` maps directly to extruder 1.
- Add `#include "GUI.hpp"` to `GUI_ObjectList.cpp` to access the new helper and indexing helpers `filament_index_from_*`.

### Testing
- No automated tests were executed for this change (GUI-only key handling changes, no `ctest`/CI run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ec6dd03c88326a89306346d05b2d5)